### PR TITLE
Auto-fill Replicate token from Pages env var

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Flux Image Generator</title>
+  <script>
+    window.REPLICATE_API_KEY = "{{ REPLICATE_API_KEY }}";
+  </script>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -197,12 +200,23 @@
       let tokenClient = null;
       let driveAccessToken = null;
 
+      const envReplicateToken =
+        typeof window !== "undefined" &&
+        typeof window.REPLICATE_API_KEY === "string" &&
+        window.REPLICATE_API_KEY &&
+        !window.REPLICATE_API_KEY.includes("{{")
+          ? window.REPLICATE_API_KEY.trim()
+          : "";
       const savedReplicateToken = localStorage.getItem("replicateToken");
       const savedClientId = localStorage.getItem("googleClientId");
       const savedFolderId = localStorage.getItem("driveFolderId");
       const savedPrompt = localStorage.getItem("lastPrompt");
 
-      if (savedReplicateToken) replicateTokenInput.value = savedReplicateToken;
+      if (envReplicateToken) {
+        replicateTokenInput.value = envReplicateToken;
+      } else if (savedReplicateToken) {
+        replicateTokenInput.value = savedReplicateToken;
+      }
       if (savedClientId) googleClientInput.value = savedClientId;
       if (savedFolderId) driveFolderInput.value = savedFolderId;
       if (savedPrompt) promptInput.value = savedPrompt;


### PR DESCRIPTION
## Summary
- expose the GitHub Pages REPLICATE_API_KEY value on window for runtime access
- prefer the injected value over the stored token when populating the Replicate field

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dd8ad278c88332a27a290386c5a9b3