### PR TITLE
Automate secret injection for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build site
+        env:
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          GOOGLE_OAUTH: ${{ secrets.GOOGLE_OAUTH }}
+        run: |
+          mkdir -p dist
+          cp index.html dist/index.html
+          node <<'NODE'
+          const fs = require('fs');
+          const config = {
+            replicateToken: process.env.REPLICATE_API_KEY || "",
+            googleClientId: process.env.GOOGLE_OAUTH || ""
+          };
+          const content = `window.APP_CONFIG = ${JSON.stringify(config, null, 2)};`;
+          fs.writeFileSync('dist/config.js', content);
+          NODE
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -48,6 +48,12 @@
       font-size: 1rem;
     }
 
+    input[readonly] {
+      background: #f0f0f0;
+      color: #555;
+      cursor: not-allowed;
+    }
+
     textarea {
       min-height: 120px;
       resize: vertical;
@@ -129,6 +135,7 @@
     }
   </style>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="config.js" defer></script>
 </head>
 <body>
   <div id="login-screen">
@@ -207,6 +214,8 @@
       if (savedFolderId) driveFolderInput.value = savedFolderId;
       if (savedPrompt) promptInput.value = savedPrompt;
 
+      applyConfig();
+
       loginForm.addEventListener("submit", function (event) {
         event.preventDefault();
         if (passwordInput.value === PASSWORD) {
@@ -220,10 +229,16 @@
       });
 
       replicateTokenInput.addEventListener("change", function () {
+        if (replicateTokenInput.dataset.locked === "true") {
+          return;
+        }
         localStorage.setItem("replicateToken", replicateTokenInput.value.trim());
       });
 
       googleClientInput.addEventListener("change", function () {
+        if (googleClientInput.dataset.locked === "true") {
+          return;
+        }
         localStorage.setItem("googleClientId", googleClientInput.value.trim());
       });
 
@@ -433,6 +448,37 @@
           };
           reader.readAsDataURL(blob);
         });
+      }
+
+      function applyConfig() {
+        if (!window.APP_CONFIG) {
+          return;
+        }
+
+        lockInput(
+          replicateTokenInput,
+          "replicateToken",
+          window.APP_CONFIG.replicateToken
+        );
+        lockInput(
+          googleClientInput,
+          "googleClientId",
+          window.APP_CONFIG.googleClientId
+        );
+      }
+
+      function lockInput(input, storageKey, value) {
+        if (!value) {
+          return;
+        }
+
+        input.value = value;
+        input.readOnly = true;
+        input.dataset.locked = "true";
+
+        if (storageKey) {
+          localStorage.removeItem(storageKey);
+        }
       }
     })();
   </script>


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow that builds a config.js file from saved secrets
- update the app to load values from the generated config and lock the credential inputs when provided

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd8bbc3f148332afa0fed54bbb1218