### PR TITLE
Load runtime secrets from generated config

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,11 +333,13 @@
     </section>
   </main>
 
+  <script src="config.js"></script>
   <script>
     (function () {
       const PASSWORD = "Appertivo2025!";
-      const REPLICATE_TOKEN = "r8_your_replicate_token";
-      const GOOGLE_CLIENT_ID = "your-client-id.apps.googleusercontent.com";
+      const CONFIG = window.APP_CONFIG || { replicateToken: "", googleClientId: "" };
+      const REPLICATE_TOKEN = CONFIG.replicateToken || "";
+      const GOOGLE_CLIENT_ID = CONFIG.googleClientId || "";
       const DRIVE_FOLDER_ID = "";
       const PROMPT_LIBRARY = [
         "Hyper-detailed digital painting of a neon-lit mech warrior emerging from ocean mist, volumetric lighting, cinematic",
@@ -390,8 +392,8 @@
 
       generateButton.addEventListener("click", async function () {
         const prompt = promptInput.value.trim();
-        if (!REPLICATE_TOKEN || REPLICATE_TOKEN.includes("your_replicate_token")) {
-          setStatus("Replicate token is missing. Update the script with your API token.");
+        if (!REPLICATE_TOKEN) {
+          setStatus("Replicate token is missing. Check your deployment secrets.");
           return;
         }
         if (!prompt) {
@@ -505,8 +507,8 @@
           return driveAccessToken;
         }
 
-        if (!GOOGLE_CLIENT_ID || GOOGLE_CLIENT_ID.includes("your-client-id")) {
-          throw new Error("Google OAuth client ID is missing in the script.");
+        if (!GOOGLE_CLIENT_ID) {
+          throw new Error("Google OAuth client ID is missing. Check your deployment secrets.");
         }
 
         if (!window.google || !google.accounts || !google.accounts.oauth2) {


### PR DESCRIPTION
## Summary
- load the Replicate and Google credentials from a config.js file populated during the Actions build
- update user feedback when the required secrets are not set

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd903814388332b2e405ba99205b2b