### PR TITLE
Show detailed error messages when generation fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,8 @@
           setStatus("Preview ready. Save it to Drive or try another idea.");
         } catch (error) {
           console.error(error);
-          setStatus("Something went wrong. Check the console for details.");
+          const message = error instanceof Error ? error.message : String(error);
+          setStatus(`Error: ${message}`);
         } finally {
           setBusy(generateButton, false);
         }


### PR DESCRIPTION
## Summary
- display the actual error message in the status area when image generation fails

## Testing
- playwright flow through login and generation (fails with network error as expected)


------
https://chatgpt.com/codex/tasks/task_e_68dd91a752248332b3d6291638f0af00